### PR TITLE
Add MiniscriptMalformed exception

### DIFF
--- a/bip380/miniscript/errors.py
+++ b/bip380/miniscript/errors.py
@@ -3,6 +3,11 @@ All the exceptions raised when dealing with Miniscript.
 """
 
 
+class MiniscriptMalformed(ValueError):
+    def __init__(self, message):
+        self.message = message
+
+
 class MiniscriptNodeCreationError(ValueError):
     def __init__(self, message):
         self.message = message

--- a/bip380/miniscript/parsing.py
+++ b/bip380/miniscript/parsing.py
@@ -5,6 +5,7 @@ Utilities to parse Miniscript from string and Script representations.
 import bip380.miniscript.fragments as fragments
 
 from bip380.key import DescriptorKey
+from bip380.miniscript.errors import MiniscriptMalformed
 from bip380.utils.script import (
     CScriptOp,
     OP_ADD,
@@ -498,7 +499,7 @@ def parse_expr_list(expr_list):
         idx -= 1
 
     # No match found.
-    raise Exception("Malformed miniscript")
+    raise MiniscriptMalformed(f"{expr_list}")
 
 
 def miniscript_from_script(script, pkh_preimages={}):

--- a/tests/test_miniscript.py
+++ b/tests/test_miniscript.py
@@ -23,6 +23,7 @@ from bitcointx.core.script import (
 from itertools import chain
 from bip380.key import DescriptorKey
 from bip380.miniscript import fragments, SatisfactionMaterial
+from bip380.miniscript.errors import MiniscriptMalformed
 from bip380.utils.script import CScript
 
 
@@ -90,11 +91,11 @@ def test_simple_sanity_checks():
     assert roundtrip("after(16407)").value == 16407
     assert roundtrip("after(1621038656)").value == 1621038656
     # CSV with a negative value
-    with pytest.raises(Exception):
-        fragments.Node.from_script(b"\x86\x92\xB2")
+    with pytest.raises(MiniscriptMalformed):
+        fragments.Node.from_script(CScript(b"\x86\x92\xB2"))
     # CLTV with a negative value
-    with pytest.raises(Exception):
-        fragments.Node.from_script(b"\x86\x92\xB1")
+    with pytest.raises(MiniscriptMalformed):
+        fragments.Node.from_script(CScript(b"\x86\x92\xB1"))
 
     roundtrip(f"pk({dummy_pk()})")
     roundtrip(f"pk_k({dummy_pk()})")


### PR DESCRIPTION
As I was doing the type hinting, I was surprised to find a `bytes` object was passed to `Node.from_script()` in `tests/test_miniscript.py` without the test failing, since a `CScript` object [is expected](https://github.com/stickies-v/python-bip380/blob/ea8f4604f749a3b75e645e1a9b5bc6b47099f637/bip380/miniscript/fragments.py#L104).

To fix that, I've added the `MiniscriptMalformed` exception, made the error handling more specific, and fixed the `Node.from_script()` call.