### PR TITLE
Keypath-spend Taproot descriptors

### DIFF
--- a/bip380/descriptors/parsing.py
+++ b/bip380/descriptors/parsing.py
@@ -47,4 +47,11 @@ def descriptor_from_str(desc_str, strict=False):
             raise DescriptorParsingError(str(e))
         return descriptors.WpkhDescriptor(pubkey)
 
+    if desc_str.startswith("tr(") and desc_str.endswith(")"):
+        try:
+            pubkey = DescriptorKey(desc_str[3:-1], x_only=True)
+        except DescriptorKeyError as e:
+            raise DescriptorParsingError(str(e))
+        return descriptors.TrDescriptor(pubkey)
+
     raise DescriptorParsingError(f"Unknown descriptor fragment: {desc_str}")

--- a/bip380/descriptors/utils.py
+++ b/bip380/descriptors/utils.py
@@ -1,0 +1,21 @@
+"""Utilities for working with descriptors."""
+import coincurve
+import hashlib
+
+
+def tagged_hash(tag, data):
+    ss = hashlib.sha256(tag.encode("utf-8")).digest()
+    ss += ss
+    ss += data
+    return hashlib.sha256(ss).digest()
+
+
+def taproot_tweak(pubkey_bytes, merkle_root):
+    assert isinstance(pubkey_bytes, bytes) and len(pubkey_bytes) == 32
+    assert isinstance(merkle_root, bytes)
+
+    t = tagged_hash("TapTweak", pubkey_bytes + merkle_root)
+    xonly_pubkey = coincurve.PublicKeyXOnly(pubkey_bytes)
+    xonly_pubkey.tweak_add(t)  # TODO: error handling
+
+    return xonly_pubkey

--- a/bip380/key.py
+++ b/bip380/key.py
@@ -1,9 +1,14 @@
+import coincurve
 import copy
 
 from bip32 import BIP32, HARDENED_INDEX
-from bip32.utils import coincurve, _deriv_path_str_to_list
+from bip32.utils import _deriv_path_str_to_list
 from bip380.utils.hashes import hash160
 from enum import Enum, auto
+
+
+def is_raw_key(obj):
+    return isinstance(obj, (coincurve.PublicKey, coincurve.PublicKeyXOnly))
 
 
 class DescriptorKeyError(Exception):
@@ -145,17 +150,26 @@ class DescriptorKey:
     May be an extended or raw public key.
     """
 
-    def __init__(self, key):
+    def __init__(self, key, x_only=False):
         # Information about the origin of this key.
         self.origin = None
         # If it is an xpub, a path toward a child key of that xpub.
         self.path = None
+        # Whether to only create x-only public keys.
+        self.x_only = x_only
 
         if isinstance(key, bytes):
-            if len(key) != 33:
-                raise DescriptorKeyError("Only compressed keys are supported")
+            if len(key) == 32:
+                key_cls = coincurve.PublicKeyXOnly
+                self.x_only = True
+            elif len(key) == 33:
+                key_cls = coincurve.PublicKey
+            else:
+                raise DescriptorKeyError(
+                    "Only compressed and x-only keys are supported"
+                )
             try:
-                self.key = coincurve.PublicKey(key)
+                self.key = key_cls(key)
             except ValueError as e:
                 raise DescriptorKeyError(f"Public key parsing error: '{str(e)}'")
 
@@ -170,9 +184,13 @@ class DescriptorKey:
                 self.origin = DescriporKeyOrigin.from_str(origin + "]")
 
             # Is it a raw key?
-            if len(key) == 66:
+            if len(key) in (64, 66):
+                pk_cls = coincurve.PublicKey
+                if len(key) == 64:
+                    pk_cls = coincurve.PublicKeyXOnly
+                    self.x_only = True
                 try:
-                    self.key = coincurve.PublicKey(bytes.fromhex(key))
+                    self.key = pk_cls(bytes.fromhex(key))
                 except ValueError as e:
                     raise DescriptorKeyError(f"Public key parsing error: '{str(e)}'")
             # If not it must be an xpub.
@@ -228,8 +246,8 @@ class DescriptorKey:
         if isinstance(self.key, BIP32):
             key += self.key.get_xpub()
         else:
-            assert isinstance(self.key, coincurve.PublicKey)
-            key += self.key.format().hex()
+            assert is_raw_key(self.key)
+            key += self.bytes().hex()
 
         if self.path is not None:
             key = ser_paths(key, self.path.paths)
@@ -262,8 +280,12 @@ class DescriptorKey:
 
         Will raise if this key contains multiple derivation paths.
         """
-        if isinstance(self.key, coincurve.PublicKey):
-            return self.key.format()
+        if is_raw_key(self.key):
+            raw = self.key.format()
+            if self.x_only and len(raw) == 33:
+                return raw[1:]
+            assert len(raw) == 32 or not self.x_only
+            return raw
         else:
             assert isinstance(self.key, BIP32)
             path = self.derivation_path()
@@ -290,7 +312,7 @@ class DescriptorKey:
 
         if self.path.kind == KeyPathKind.WILDCARD_HARDENED:
             index += 2 ** 31
-        assert index <= 2 ** 32
+        assert index < 2 ** 32
 
         if self.origin is None:
             fingerprint = hash160(self.key.pubkey)[:4]

--- a/bip380/miniscript/fragments.py
+++ b/bip380/miniscript/fragments.py
@@ -653,7 +653,8 @@ class OrC(Node):
         exec_info = ExecutionInfo.from_or_uneven(
             self.subs[0].exec_info, self.subs[1].exec_info, ops_count=2
         )
-        return exec_info.set_undissatisfiable()  # it's V.
+        exec_info.set_undissatisfiable()  # it's V.
+        return exec_info
 
     def satisfaction(self, sat_material):
         return Satisfaction.from_or_uneven(sat_material, self.subs[0], self.subs[1])

--- a/bip380/miniscript/fragments.py
+++ b/bip380/miniscript/fragments.py
@@ -227,7 +227,6 @@ class PkNode(Node):
         return [self.pubkey]
 
 
-# TODO: A PkNode class to inherit those two from?
 class Pk(PkNode):
     def __init__(self, pubkey):
         PkNode.__init__(self, pubkey)

--- a/bip380/miniscript/satisfaction.py
+++ b/bip380/miniscript/satisfaction.py
@@ -100,7 +100,6 @@ class Satisfaction:
 
         # > Otherwise, all not-DONTUSE options are valid, so return the smallest one (in
         # > terms of witness size).
-        # FIXME: the C++ implem uses number of stack elements
         if self.size() > other.size():
             return other
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bip32~=3.0
+coincurve~=18.0

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -69,6 +69,10 @@ def verify_tx(descriptor, tx, witness_stack, amount):
     )
 
 
+def roundtrip_desc(desc_str):
+    assert str(Descriptor.from_str(desc_str)) == desc_str
+
+
 def test_wsh_sanity_checks():
     """Sanity check we can parse a wsh descriptor and satisfy it."""
     hd = BIP32.from_seed(os.urandom(32))
@@ -436,12 +440,18 @@ def test_taproot_descriptors():
     # Taken from Bitcoin Core unit tests.
     sanity_check_spk(
         "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
-        "512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11"
+        "512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11",
+    )
+    roundtrip_desc(
+        "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#dh4fyxrd"
     )
     # Taken from rust-miniscript unit tests.
     sanity_check_spk(
         "tr(02e20e746af365e86647826397ba1c0e0d5cb685752976fe2f326ab76bdc4d6ee9)",
-        "51209c19294f03757da3dc235a5960631e3c55751632f5889b06b7a053bdc0bcfbcb"
+        "51209c19294f03757da3dc235a5960631e3c55751632f5889b06b7a053bdc0bcfbcb",
+    )
+    roundtrip_desc(
+        "tr(02e20e746af365e86647826397ba1c0e0d5cb685752976fe2f326ab76bdc4d6ee9)#f7yg99rk"
     )
 
     # Works for derived keys too. Taken and adapted from rust-miniscript unit tests.

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -100,9 +100,9 @@ def test_wpkh_sanity_checks():
     verify_tx(desc, tx, stack, amount)
 
 
-def test_xpub_parsing():
-    """Roundtrip xpubs with various metadata."""
-    xpubs = [
+def test_key_parsing():
+    """Roundtrip keys with various metadata."""
+    keys = [
         "[aabbccdd]xpub661MyMwAqRbcGC7awXn2f36qPMLE2x42cQM5qHrSRg3Q8X7qbDEG1aKS4XAA1PcWTZn7c4Y2WJKCvcivjpZBXTo8fpCRrxtmNKW4H1rpACa",
         "[aabbccdd/0/1'/2]xpub661MyMwAqRbcGC7awXn2f36qPMLE2x42cQM5qHrSRg3Q8X7qbDEG1aKS4XAA1PcWTZn7c4Y2WJKCvcivjpZBXTo8fpCRrxtmNKW4H1rpACa",
         "xpub661MyMwAqRbcGC7awXn2f36qPMLE2x42cQM5qHrSRg3Q8X7qbDEG1aKS4XAA1PcWTZn7c4Y2WJKCvcivjpZBXTo8fpCRrxtmNKW4H1rpACa/1'/2",
@@ -115,9 +115,13 @@ def test_xpub_parsing():
         "tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/2/<0;1;9854>/3456/9876/*",
         "[abcdef00/0'/1']tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/<0;1>/*",
         "[abcdef00/0'/1']tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/9478'/<0';1'>/8'/*'",
+        "02cc24adfed5a481b000192042b2399087437d8eb16095c3dda1d45a4fbf868017",
+        "[0011bbdd/534/789'/34]033d65a099daf8d973422e75f78c29504e5e53bfb81f3b08d9bb161cdfb3c3ee9a",
+        "cc24adfed5a481b000192042b2399087437d8eb16095c3dda1d45a4fbf868017",
+        "[0011bbdd/534/789'/34]3d65a099daf8d973422e75f78c29504e5e53bfb81f3b08d9bb161cdfb3c3ee9a",
     ]
-    for xpub in xpubs:
-        assert str(DescriptorKey(xpub)) == xpub
+    for key in keys:
+        assert str(DescriptorKey(key)) == key
 
     tpub = DescriptorKey(
         "[abcdef00/0'/1]tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/9478'/<0';1';420>/8'/*'"


### PR DESCRIPTION
This introduces partial support for Taproot descriptors, without the tree expression.